### PR TITLE
add pass-the-hash capability

### DIFF
--- a/spec/lib/net/ntlm_spec.rb
+++ b/spec/lib/net/ntlm_spec.rb
@@ -51,6 +51,14 @@ describe Net::NTLM do
     expect(Net::NTLM::ntlmv2_hash(user, passwd, domain)).to eq(["04b8e0ba74289cc540826bab1dee63ae"].pack("H*"))
   end
 
+  context 'when a user passes an NTLM hash for pass-the-hash' do
+    let(:passwd) { Net::NTLM::EncodeUtil.encode_utf16le('ff3750bcc2b22412c2265b23734e0dac:cd06ca7c7e10c99b1d33b7485a2ed808') }
+
+    it 'should return the correct ntlmv2 hash' do
+      expect(Net::NTLM::ntlmv2_hash(user, passwd, domain)).to eq(["04b8e0ba74289cc540826bab1dee63ae"].pack("H*"))
+    end
+  end
+
   it 'should generate an lm_response' do
     expect(Net::NTLM::lm_response(
         {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'simplecov'
+require 'pathname'
+
 SimpleCov.start do
   add_filter '/spec/'
   add_filter '/config/'


### PR DESCRIPTION
a user can enter a full NTLM hash
in LM:NTLM format for the client password
and the library will use the supplied ntlm hash
for generating the ntlmv2 hash

MSP-12777

VERIFICATION STEPS
- [x] pull down https://github.com/rapid7/smb2
- [x] in smb2.gemspec comment out the line `spec.add_runtime_dependency "rubyntlm", "~> 0.5"`
- [x] add a line to the Gemfile in smb2 `gem 'rubyntlm`, path: <path to your local copy of this repo.
- [x] in the smb2 directory `bundle console`
- [x] use the following code, replace the ip, username, the ntlm hash as is appropriate for your own target environment(make sure it is a Vista or later OS!)

```
dispatcher = Smb2::Dispatcher::Socket.connect("192.168.172.163", 445)
client = Smb2::Client.new(
  dispatcher: dispatcher,
  username:"msfadmin",
  password:"aad3b435b51404eeaad3b435b51404ee:27c433245e4763d074d30a05aae0af2c",
  domain:"corp"
)
client.negotiate
client.authenticate
```
- [x] VERIFY it authenticates successfully (it should return 0)
